### PR TITLE
deployment: adding ember-cli-deploy-cloudfront for invalidations

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -33,6 +33,8 @@ module.exports = function(deployTarget) {
     ENV["s3-index"].region = 'ap-southeast-1';
     ENV.cloudfront = {
       distribution: 'E2TZ3PLCL45IAQ',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
       objectPaths: [ '/', '/*', '/**/*', '/index.html' ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5800,6 +5800,27 @@
         "rsvp": "^3.5.0"
       }
     },
+    "ember-cli-deploy-cloudfront": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-cloudfront/-/ember-cli-deploy-cloudfront-1.3.0.tgz",
+      "integrity": "sha512-zHCcnDvaRRVKkZgFn1teXXMyn7/gKGdHPo/qGDjtuXygIcB8bK+hbi2gjX8P0Bc4d/U4l8SaQJuKThLi43ehmg==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.252.1",
+        "core-object": "^3.1.5",
+        "ember-cli-deploy-plugin": "~0.2.9",
+        "rsvp": "^4.8.2",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "4.8.4",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+          "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+          "dev": true
+        }
+      }
+    },
     "ember-cli-deploy-display-revisions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-deploy-display-revisions/-/ember-cli-deploy-display-revisions-1.0.0.tgz",
@@ -9239,7 +9260,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9260,12 +9282,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9280,17 +9304,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9407,7 +9434,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9419,6 +9447,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9433,6 +9462,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9440,12 +9470,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9464,6 +9496,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9544,7 +9577,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9556,6 +9590,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9641,7 +9676,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9677,6 +9713,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9696,6 +9733,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9739,12 +9777,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-cli-babel": "^6.16.0",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-deploy": "^1.0.2",
+    "ember-cli-deploy-cloudfront": "^1.3.0",
     "ember-cli-deploy-s3-pack": "^1.0.0-beta.5",
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-fastboot": "^2.0.0",


### PR DESCRIPTION
Fixes #20 

Part of the config for this was already added but the required ember-addon wasn't installed 👍 

This mostly needs to be a "test in production" situation to see if it does what it is supposed to. Once the PR is merged we will see the result of the operation in the Travis log 👍 